### PR TITLE
prevent iframe cross-origin errors 

### DIFF
--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -29,7 +29,13 @@ exports.aceEditEvent = function(hook_name, args, cb){
 }
 
 exports.userActive = function(){
-  if(window.parent.document.title[0] == "*"){
-    window.parent.document.title = window.parent.document.title.substring(1,window.parent.document.title.length);
+  try {
+    window.top.document; 
+  } catch(e) { 
+    /* top-level document is not accessible */ 
+    return; 
+  } 
+  if(window.top.document.title[0] == "*"){
+    window.top.document.title = window.top.document.title.substring(1,window.top.document.title.length);
   }
 }

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -14,17 +14,24 @@ exports.postAceInit = function(hook, context){
 
 
 exports.aceEditEvent = function(hook_name, args, cb){
+  try {
+    window.top.document;
+  } catch(e) {
+    /* top-level document is not accessible */
+    return;
+  }
+
   var caretMoving = ( args.callstack.type == "applyChangesToBase" );
   if(!caretMoving) return false;
 
-  if(window.parent.document.title[0] !== "*"){
-    if(window.parent.document.title[0] === "*"){
-      var prevTitle = window.parent.document.title.substring(2,window.parent.document.title.length);
+  if(window.top.document.title[0] !== "*"){
+    if(window.top.document.title[0] === "*"){
+      var prevTitle = window.top.document.title.substring(2,window.top.document.title.length);
     }else{
-      var prevTitle = window.parent.document.title;
+      var prevTitle = window.top.document.title;
     }
     var newTitle = "* "+prevTitle
-    window.parent.document.title = newTitle;
+    window.top.document.title = newTitle;
   }
 }
 


### PR DESCRIPTION
Accessing window.document is not allowed if the window is on a different origin than the executing code is loaded from.
This happens when etherpad is embedded in an iframe from a different domain.

This fix also uses window.top instead of window.parent to ensure we access the top-most document to update the title.

fixes #1